### PR TITLE
Fix reference name to the logger

### DIFF
--- a/LoggingProxy.swift
+++ b/LoggingProxy.swift
@@ -8,7 +8,7 @@
 
 import Willow
 
-var logger = LoggingProxy(logger: willowLogger)
+var logger = LoggingProxy(logger: willow_logger)
 
 // swiftformat:disable redundantSelf
 struct LoggingProxy {


### PR DESCRIPTION
In `LoggingConfiguration.swift` file the declared variable is `willow_logger` not `willowLogger`